### PR TITLE
Allow setting AmzSecretKey per request

### DIFF
--- a/amazon.js
+++ b/amazon.js
@@ -44,7 +44,7 @@ var initializeAmazon = function (initOptions) {
     var queryString = query.join('\n');
 
 
-    var hmac = HmacSHA256(queryString, initOptions.AmzSecretKey);
+    var hmac = HmacSHA256(queryString, options.AmzSecretKey || initOptions.AmzSecretKey);
     var signature = base64.stringify(hmac);
 
     paramsString += '&Signature=' + encodeURIComponent(signature);


### PR DESCRIPTION
This is to allow greater flexibility, in case one would need to send requests using different Amazon accounts without having to initiate multiple MWS functions